### PR TITLE
Simplify mc server commands

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,7 @@
+from .init import register_init_command
+from .start import register_start_command
+
+__all__ = [
+    "register_init_command",
+    "register_start_command",
+]

--- a/src/cli/init.py
+++ b/src/cli/init.py
@@ -1,0 +1,30 @@
+import sys
+from scripts.init import init_command
+from auth import get_authentication_token
+
+
+def register_init_command(subparsers):
+    parser = subparsers.add_parser("init", help="Initialize client configuration")
+    parser.add_argument(
+        "api_key",
+        nargs="?",
+        help="SingleStore API key (optional, will use web auth if not provided)",
+    )
+    parser.add_argument(
+        "--client",
+        default="claude",
+        choices=["claude", "cursor"],
+        help="LLM client to configure (default: claude)",
+    )
+    parser.set_defaults(func=handle_init_command)
+
+
+def handle_init_command(args, mcp=None):
+    api_key = getattr(args, "api_key", None)
+    auth_token = None
+    if not api_key:
+        auth_token = get_authentication_token()
+        if not auth_token:
+            print("No API key provided and authentication failed.")
+            sys.exit(1)
+    sys.exit(init_command(api_key, auth_token, args.client))

--- a/src/cli/start.py
+++ b/src/cli/start.py
@@ -1,0 +1,54 @@
+from src.config import app_config, AuthMethod
+import os
+
+
+def register_start_command(subparsers):
+    parser = subparsers.add_parser("start", help="Start the MCP server")
+    parser.add_argument(
+        "api_key",
+        nargs="?",
+        help="SingleStore API key (optional, will use web auth if not provided)",
+    )
+    parser.add_argument(
+        "--protocol",
+        default="stdio",
+        choices=["stdio", "sse", "http"],
+        help="Protocol to run the server on (default: stdio)",
+    )
+    parser.add_argument(
+        "--port",
+        default=8000,
+        type=int,
+        help="Port to run the server on (default: 8000) if protocol is sse",
+    )
+    parser.set_defaults(func=handle_start_command)
+
+
+def handle_start_command(args, mcp):
+    protocol = getattr(args, "protocol", "stdio")
+    if getattr(args, "api_key", None):
+        print(
+            f"Using provided API key: {args.api_key[:10]}{'*' * (len(args.api_key) - 10)}"
+        )
+        app_config.set_auth_token(args.api_key, AuthMethod.API_KEY)
+    elif os.getenv("SINGLESTORE_API_KEY"):
+        print("Using API key from environment variable SINGLESTORE_API_KEY")
+        app_config.set_auth_token(os.getenv("SINGLESTORE_API_KEY"), AuthMethod.API_KEY)
+    if protocol == "sse":
+        print(
+            f"Running SSE server with protocol {protocol.upper()} on port {args.port}"
+        )
+        app_config.set_server_port(args.port)
+        app_config.server_mode = "sse"
+    elif protocol == "http":
+        protocol = "streamable-http"
+        print(
+            f"Running Streamable HTTP server with protocol {protocol.upper()} on port {args.port}"
+        )
+        app_config.set_server_port(args.port)
+        app_config.server_mode = "stdio"
+    else:
+        print(f"Running server with protocol {protocol.upper()}")
+        app_config.server_mode = "stdio"
+    mcp.settings.port = app_config.get_server_port()
+    mcp.run(transport=protocol)

--- a/src/commands.py
+++ b/src/commands.py
@@ -1,0 +1,6 @@
+def register_all_commands(subparsers):
+    from src.cli import register_start_command, register_init_command
+
+    register_start_command(subparsers)
+    register_init_command(subparsers)
+    # Add new command registrations here

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,6 +1,0 @@
-# Constants shared across the project
-
-CLIENT_ID = "your-client-id"
-OAUTH_HOST = "https://oauth.example.com"
-AUTH_TIMEOUT_SECONDS = 300
-ROOT_DIR = "/app"


### PR DESCRIPTION
Pass the cli commands to a new directory called `cli`. There are two commands:
- `start`: starts the server with the proper commands
- `init`: locally configures the server